### PR TITLE
Update log4j to 2.17.1 to address CVE-2021-44832.

### DIFF
--- a/ser/jackson/fasterxml/pom.xml
+++ b/ser/jackson/fasterxml/pom.xml
@@ -23,7 +23,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <log4j.version>2.7</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2021-44832
